### PR TITLE
 Implement chevron indicator and update icon scaling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,40 +2,39 @@ project(
     'wingpanel-indicator-appicontray',
     'vala', 'c',
     version: '1.0.0',
-    license: 'GPL-3.0+'
+    license: 'GPL-3.0+',
+    meson_version: '>= 0.58.0'
 )
 
-gettext_name = meson.project_name()
 gnome = import('gnome')
 i18n = import('i18n')
 
-add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
-
-# Add custom VAPI directory
-add_project_arguments(
-    '--vapidir', meson.current_source_dir() / 'vapi',
-    language: 'vala'
-)
-
-# Get wingpanel indicators directory
-wingpanel_dep = dependency('wingpanel')
-indicators_dir = wingpanel_dep.get_pkgconfig_variable('indicatorsdir')
-
 # Core dependencies
 dependencies = [
-    wingpanel_dep,
+    dependency('wingpanel'),
     dependency('granite'),
     dependency('gtk+-3.0'),
     dependency('glib-2.0'),
     dependency('gobject-2.0'),
     dependency('gio-2.0'),
     dependency('gee-0.8'),
-    dependency('gdk-pixbuf-2.0')
+    dependency('gdk-pixbuf-2.0'),
+    dependency('dbusmenu-gtk3-0.4')
 ]
 
-# Add DBusMenu dependencies
-dbusmenu_gtk = dependency('dbusmenu-gtk3-0.4', required: true)
-dependencies += dbusmenu_gtk
+# Get installation directory safely
+wingpanel_dep = dependency('wingpanel')
+indicators_dir = wingpanel_dep.get_variable(pkgconfig: 'indicatorsdir')
+
+# Global C arguments
+add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language: 'c')
+
+# Vala compilation arguments
+vala_args = [
+    '--pkg=posix',
+    '--pkg=dbusmenu-gtk3-0.4',
+    '--vapidir=' + meson.current_source_dir() / 'vapi'
+]
 
 # Source files
 indicator_files = files(
@@ -51,12 +50,7 @@ shared_library(
     meson.project_name(),
     indicator_files,
     dependencies: dependencies,
-    vala_args: [
-        '--pkg=posix',
-        '--pkg=dbusmenu-gtk3-0.4',
-        '--vapidir=' + meson.current_source_dir() / 'vapi'
-    ],
+    vala_args: vala_args,
     install: true,
     install_dir: indicators_dir
 )
-

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -6,7 +6,8 @@
  */
 
 public class AppicontrayIndicator : Wingpanel.Indicator {
-    private Gtk.Box? display_widget = null;
+    private Gtk.Grid? display_widget = null;
+    private Gtk.Image? display_icon = null;
     private StatusNotifierHost host;
     private StatusNotifierWatcher? watcher;
 
@@ -14,14 +15,20 @@ public class AppicontrayIndicator : Wingpanel.Indicator {
         Object(
             code_name: "appicontray-indicator"
         );
-        this.visible = false;
+        this.visible = true;
     }
 
     construct {
         // Construction and display container
         debug("Constructing AppIconTray Indicator");
-        display_widget = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-        display_widget.get_style_context().add_class("appicontray");
+        display_icon = new Gtk.Image.from_icon_name("pan-down-symbolic", Gtk.IconSize.MENU);
+        display_icon.set_pixel_size(16);
+        display_icon.get_style_context().add_class("appicontray-indicator-icon");
+        display_icon.set_tooltip_text(_("Other App Indicator Icons"));
+
+
+        display_widget = new Gtk.Grid();
+        display_widget.get_style_context().add_class("appicontray-indicator");
 
         // Register D-Bus watcher, print only result of registration
         watcher = new StatusNotifierWatcher();
@@ -50,18 +57,24 @@ public class AppicontrayIndicator : Wingpanel.Indicator {
     }
 
     public override Gtk.Widget get_display_widget() {
-        return display_widget;
+        // Now return the icon instead of null
+        return display_icon;
     }
-    public override Gtk.Widget? get_widget() { return null; }
-    public override void opened() {}
-    public override void closed() {}
+    public override Gtk.Widget? get_widget() { return display_widget; }
+    public override void opened() {display_icon.set_from_icon_name("pan-up-symbolic", Gtk.IconSize.MENU);}
+    public override void closed() {display_icon.set_from_icon_name("pan-down-symbolic", Gtk.IconSize.MENU);}
 
     private void on_icon_added(TrayIcon icon) {
         if (display_widget == null) {
             critical("display_widget is null in on_icon_added!");
             return;
         }
-        display_widget.pack_start(icon, false, false, 0);
+
+        icon.clicked.connect(() => {
+            close();
+        });
+
+        display_widget.add(icon);
         icon.show_all();
         this.visible = true;
     }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -14,7 +14,7 @@ public class AppicontrayIndicator : Wingpanel.Indicator {
         Object(
             code_name: "appicontray-indicator"
         );
-        visible = false;
+        this.visible = false;
     }
 
     construct {
@@ -26,13 +26,18 @@ public class AppicontrayIndicator : Wingpanel.Indicator {
         // Register D-Bus watcher, print only result of registration
         watcher = new StatusNotifierWatcher();
         watcher.register_on_bus.begin((obj, res) => {
-            bool registered = watcher.register_on_bus.end(res);
-            if (registered) {
-                debug("StatusNotifierWatcher service registered");
-            } else {
-                debug("Using existing StatusNotifierWatcher service");
+            try {
+                bool registered = watcher.register_on_bus.end(res);
+                if (registered) {
+                    debug("StatusNotifierWatcher service registered");
+                } else {
+                    debug("Using existing StatusNotifierWatcher service");
+                }
+                initialize_host();
+            } catch (GLib.Error e) {
+                // Handle the failure to register
+                warning("Failed to register StatusNotifierWatcher: %s", e.message);
             }
-            initialize_host();
         });
     }
 
@@ -58,7 +63,7 @@ public class AppicontrayIndicator : Wingpanel.Indicator {
         }
         display_widget.pack_start(icon, false, false, 0);
         icon.show_all();
-        visible = true;
+        this.visible = true;
     }
 
     private void on_icon_removed(TrayIcon icon) {
@@ -69,7 +74,7 @@ public class AppicontrayIndicator : Wingpanel.Indicator {
         display_widget.remove(icon);
         GLib.List<weak Gtk.Widget> children = display_widget.get_children();
         if (children.length() == 0) {
-            visible = false;
+            this.visible = false;
         }
     }
 }

--- a/src/StatusNotifierHost.vala
+++ b/src/StatusNotifierHost.vala
@@ -20,26 +20,21 @@ public class StatusNotifierHost : Object {
     }
     
     public async void start() {
-        try {
-            // Own our host service name
-            host_name_id = Bus.own_name(
-                BusType.SESSION,
-                host_service_name,
-                BusNameOwnerFlags.NONE,
-                null,
-                null,
-                null
-            );
+        // Own our host service name
+        host_name_id = Bus.own_name(
+            BusType.SESSION,
+            host_service_name,
+            BusNameOwnerFlags.NONE,
+            null,
+            null,
+            null
+        );
 
-            // Give the bus a moment to register our name
-            Timeout.add(100, () => {
-                connect_to_watcher.begin();
-                return false;
-            });
-
-        } catch (Error e) {
-            critical("Failed to start StatusNotifierHost: %s", e.message);
-        }
+        // Give the bus a moment to register our name
+        Timeout.add(100, () => {
+            connect_to_watcher.begin();
+            return false;
+        });
     }
     
     private async void connect_to_watcher() {

--- a/src/StatusNotifierWatcher.vala
+++ b/src/StatusNotifierWatcher.vala
@@ -94,9 +94,13 @@ public class StatusNotifierWatcher : Object {
             bus_name = service;
             debug("Registering standard SNI item: %s", service_to_emit);
         }
-        registered_items.add(service_to_emit);
-        item_registered(service_to_emit);
-        StatusNotifierItemRegistered(service_to_emit);
+
+        if (!service_to_emit.contains("nm_applet")) {
+            registered_items.add(service_to_emit);
+            item_registered(service_to_emit);
+            StatusNotifierItemRegistered(service_to_emit);
+            debug("StatusNotifierItem registered: %s", service_to_emit);
+        }
 
         // Monitor when service disconnects
         Bus.watch_name(

--- a/src/StatusNotifierWatcher.vala
+++ b/src/StatusNotifierWatcher.vala
@@ -25,7 +25,7 @@ public class StatusNotifierWatcher : Object {
         registered_hosts = new Gee.ArrayList<string>();
     }
     
-    public async bool register_on_bus() {
+    public async bool register_on_bus() throws DBusError, IOError {
         try {
             connection = yield Bus.get(BusType.SESSION);
             try {

--- a/src/TrayIcon.vala
+++ b/src/TrayIcon.vala
@@ -19,6 +19,7 @@ public class TrayIcon : Gtk.EventBox {
 
     public signal void ready();
     public signal void removed();
+    public signal void clicked();
 
     public TrayIcon(string service_name, string bus_name, string object_path) {
         this.service_name = service_name;
@@ -26,8 +27,8 @@ public class TrayIcon : Gtk.EventBox {
         this.object_path = object_path;
 
         icon_image = new Gtk.Image();
-        icon_image.pixel_size = 16;
-        icon_image.margin = 6;
+        icon_image.pixel_size = 20;
+        icon_image.margin = 12;
         add(icon_image);
 
         set_visible_window(false);
@@ -251,7 +252,7 @@ public class TrayIcon : Gtk.EventBox {
         IconPixmapStruct[]? pixmaps = needs_attention ? get_attention_icon_pixmap() : get_icon_pixmap();
         if (pixmaps != null && pixmaps.length > 0 && load_icon_from_pixmap(pixmaps)) return;
         icon_image.set_from_icon_name("application-x-executable", Gtk.IconSize.SMALL_TOOLBAR);
-        icon_image.pixel_size = 16;
+        icon_image.pixel_size = 20;
     }
 
     private bool load_icon_from_path(string base_path, string icon_name) {
@@ -276,7 +277,7 @@ public class TrayIcon : Gtk.EventBox {
         int best_idx = 0;
         int best_diff = int.MAX;
         for (int i = 0; i < pixmaps.length; i++) {
-            int size_diff = (pixmaps[i].width - 16).abs() + (pixmaps[i].height - 16).abs();
+            int size_diff = (pixmaps[i].width - 20).abs() + (pixmaps[i].height - 20).abs();
             if (size_diff < best_diff) {
                 best_diff = size_diff;
                 best_idx = i;
@@ -306,8 +307,8 @@ public class TrayIcon : Gtk.EventBox {
             Gdk.Colorspace.RGB,
             true, 8, width, height, width * 4
         );
-        if (width != 16 || height != 16)
-            pixbuf = pixbuf.scale_simple(16, 16, Gdk.InterpType.BILINEAR);
+        if (width != 20 || height != 20)
+            pixbuf = pixbuf.scale_simple(20, 20, Gdk.InterpType.BILINEAR);
         icon_image.set_from_pixbuf(pixbuf);
         return true;
     }
@@ -337,6 +338,7 @@ public class TrayIcon : Gtk.EventBox {
                 freedesktop_proxy.Activate.begin(x, y);
             else if (item_proxy != null)
                 item_proxy.Activate.begin(x, y);
+            this.clicked();
         } else if (event.button == Gdk.BUTTON_SECONDARY) {
             if (dbusmenu != null)
                 dbusmenu.popup_at_pointer(event);

--- a/src/TrayIcon.vala
+++ b/src/TrayIcon.vala
@@ -334,27 +334,55 @@ public class TrayIcon : Gtk.EventBox {
         int x = (int)event.x_root;
         int y = (int)event.y_root;
         if (event.button == Gdk.BUTTON_PRIMARY) {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                freedesktop_proxy.Activate.begin(x, y);
-            else if (item_proxy != null)
-                item_proxy.Activate.begin(x, y);
-            this.clicked();
-        } else if (event.button == Gdk.BUTTON_SECONDARY) {
-            if (dbusmenu != null)
-                dbusmenu.popup_at_pointer(event);
-            else {
-                if (use_freedesktop_interface && freedesktop_proxy != null)
-                    freedesktop_proxy.ContextMenu.begin(x, y);
-                else if (item_proxy != null)
-                    item_proxy.ContextMenu.begin(x, y);
+            if (use_freedesktop_interface && freedesktop_proxy != null) {
+                freedesktop_proxy.Activate.begin(x, y, (obj, res) => {
+                    try {
+                        freedesktop_proxy.Activate.end(res);
+                        this.clicked();
+                    } catch (GLib.Error e) {
+                        if (dbusmenu != null) {
+                            dbusmenu.popup_at_pointer(event);
+                        } else {
+                            freedesktop_proxy.ContextMenu.begin(x, y);
+                        }
+                    }
+                });
+            } else if (item_proxy != null) {
+                item_proxy.Activate.begin(x, y, (obj, res) => {
+                    try {
+                        item_proxy.Activate.end(res);
+                        this.clicked();
+                    } catch (GLib.Error e) {
+                        if (dbusmenu != null) {
+                            dbusmenu.popup_at_pointer(event);
+                        } else {
+                            item_proxy.ContextMenu.begin(x, y);
+                        }
+                    }
+                });
             }
-        } else if (event.button == Gdk.BUTTON_MIDDLE) {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
+        } else if (event.button == Gdk.BUTTON_SECONDARY) {
+            if (dbusmenu != null) {
+                dbusmenu.popup_at_pointer(event);
+            } else {
+                // Manual fallback if no dbusmenu is provided
+                if (use_freedesktop_interface && freedesktop_proxy != null) {
+                    freedesktop_proxy.ContextMenu.begin(x, y);
+                } else if (item_proxy != null) {
+                    item_proxy.ContextMenu.begin(x, y);
+                }
+            }
+        } 
+
+        else if (event.button == Gdk.BUTTON_MIDDLE) {
+            if (use_freedesktop_interface && freedesktop_proxy != null) {
                 freedesktop_proxy.SecondaryActivate.begin(x, y);
-            else if (item_proxy != null)
+            } else if (item_proxy != null) {
                 item_proxy.SecondaryActivate.begin(x, y);
+            }
         }
-        return true;
+
+        return false;
     }
 
     private bool on_scroll(Gdk.EventScroll event) {

--- a/src/TrayIcon.vala
+++ b/src/TrayIcon.vala
@@ -53,22 +53,14 @@ public class TrayIcon : Gtk.EventBox {
         update_icon();
         update_tooltip();
 
-        try {
-            string status = get_status();
-            debug("TrayIcon '%s' initial status: '%s'", service_name, status ?? "(null)");
-            if (status != null && status != "") handle_status_change(status);
-        } catch (Error e) {
-            debug("TrayIcon '%s' could not get status: %s", service_name, e.message);
-        }
+        string status = get_status();
+        debug("TrayIcon '%s' initial status: '%s'", service_name, status ?? "(null)");
+        if (status != null && status != "") handle_status_change(status);
 
-        try {
-            var menu_path = get_menu_path();
-            if (menu_path != null && menu_path != "/" && menu_path != "") {
-                debug("TrayIcon '%s': Initializing DBusMenu at %s", service_name, (string)menu_path);
-                dbusmenu = new DbusmenuGtk.Menu(bus_name, menu_path);
-            }
-        } catch (Error e) {
-            debug("TrayIcon '%s': Menu init error: %s", service_name, e.message);
+        var menu_path = get_menu_path();
+        if (menu_path != null && menu_path != "/" && menu_path != "") {
+            debug("TrayIcon '%s': Initializing DBusMenu at %s", service_name, (string)menu_path);
+            dbusmenu = new DbusmenuGtk.Menu(bus_name, menu_path);
         }
 
         is_ready = true;
@@ -88,29 +80,7 @@ public class TrayIcon : Gtk.EventBox {
         if (!success) success = yield try_freedesktop_interface();
         if (!success) return false;
 
-        yield introspect_properties();
         return true;
-    }
-
-    private async void introspect_properties() {
-        if (connection == null) return;
-        try {
-            var result = yield connection.call(
-                bus_name,
-                object_path,
-                "org.freedesktop.DBus.Properties",
-                "GetAll",
-                new Variant("(s)", use_freedesktop_interface ?
-                    "org.freedesktop.StatusNotifierItem" :
-                    "org.kde.StatusNotifierItem"),
-                new VariantType("(a{sv})"),
-                DBusCallFlags.NONE,
-                -1,
-                null
-            );
-        } catch (Error e) {
-            debug("TrayIcon '%s': Error introspecting properties: %s", service_name, e.message);
-        }
     }
 
     private async bool try_kde_interface() {
@@ -122,20 +92,18 @@ public class TrayIcon : Gtk.EventBox {
                 DBusProxyFlags.NONE
             );
             if (item_proxy == null) return false;
-            try { var test_id = item_proxy.Id; }
-            catch (Error e) { item_proxy = null; return false; }
 
             // On icon change, recreate proxies then update the icon
             item_proxy.NewIcon.connect(() => {
                 recreate_proxy.begin((obj, res) => {
-                    try { recreate_proxy.end(res); } catch (Error e) {}
+                    recreate_proxy.end(res);
                     update_icon();
                 });
             });
             item_proxy.NewStatus.connect((status) => handle_status_change(status));
             item_proxy.NewAttentionIcon.connect(() => {
                 recreate_proxy.begin((obj, res) => {
-                    try { recreate_proxy.end(res); } catch (Error e) {}
+                    recreate_proxy.end(res);
                     update_icon();
                 });
             });
@@ -159,19 +127,17 @@ public class TrayIcon : Gtk.EventBox {
                 DBusProxyFlags.NONE
             );
             if (freedesktop_proxy == null) return false;
-            try { var test_id = freedesktop_proxy.Id; }
-            catch (Error e) { freedesktop_proxy = null; return false; }
 
             freedesktop_proxy.NewIcon.connect(() => {
                 recreate_proxy.begin((obj, res) => {
-                    try { recreate_proxy.end(res); } catch (Error e) {}
+                    recreate_proxy.end(res);
                     update_icon();
                 });
             });
             freedesktop_proxy.NewStatus.connect((status) => handle_status_change(status));
             freedesktop_proxy.NewAttentionIcon.connect(() => {
                 recreate_proxy.begin((obj, res) => {
-                    try { recreate_proxy.end(res); } catch (Error e) {}
+                    recreate_proxy.end(res);
                     update_icon();
                 });
             });
@@ -187,83 +153,67 @@ public class TrayIcon : Gtk.EventBox {
     }
 
     private string? get_icon_name() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.IconName;
-            else if (item_proxy != null)
-                return item_proxy.IconName;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.IconName;
+        else if (item_proxy != null)
+            return item_proxy.IconName;
+        return null;
     }
 
     private string? get_icon_theme_path() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.IconThemePath;
-            else if (item_proxy != null)
-                return item_proxy.IconThemePath;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.IconThemePath;
+        else if (item_proxy != null)
+            return item_proxy.IconThemePath;
+        return null;
     }
 
     private IconPixmapStruct[]? get_icon_pixmap() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.IconPixmap;
-            else if (item_proxy != null)
-                return item_proxy.IconPixmap;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.IconPixmap;
+        else if (item_proxy != null)
+            return item_proxy.IconPixmap;
+        return null;
     }
 
     private string? get_attention_icon_name() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.AttentionIconName;
-            else if (item_proxy != null)
-                return item_proxy.AttentionIconName;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.AttentionIconName;
+        else if (item_proxy != null)
+            return item_proxy.AttentionIconName;
+        return null;
     }
 
     private IconPixmapStruct[]? get_attention_icon_pixmap() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.AttentionIconPixmap;
-            else if (item_proxy != null)
-                return item_proxy.AttentionIconPixmap;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.AttentionIconPixmap;
+        else if (item_proxy != null)
+            return item_proxy.AttentionIconPixmap;
+        return null;
     }
 
     private string? get_title() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.Title;
-            else if (item_proxy != null)
-                return item_proxy.Title;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.Title;
+        else if (item_proxy != null)
+            return item_proxy.Title;
+        return null;
     }
 
     private string? get_status() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.Status;
-            else if (item_proxy != null)
-                return item_proxy.Status;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.Status;
+        else if (item_proxy != null)
+            return item_proxy.Status;
+        return null;
     }
 
     private ObjectPath? get_menu_path() {
-        try {
-            if (use_freedesktop_interface && freedesktop_proxy != null)
-                return freedesktop_proxy.Menu;
-            else if (item_proxy != null)
-                return item_proxy.Menu;
-            return null;
-        } catch (Error e) { return null; }
+        if (use_freedesktop_interface && freedesktop_proxy != null)
+            return freedesktop_proxy.Menu;
+        else if (item_proxy != null)
+            return item_proxy.Menu;
+        return null;
     }
 
     private void update_icon() {
@@ -295,7 +245,7 @@ public class TrayIcon : Gtk.EventBox {
                     var pixbuf = new Gdk.Pixbuf.from_file_at_scale(icon_name, 16, 16, true);
                     icon_image.set_from_pixbuf(pixbuf);
                     return;
-                } catch (Error e) {}
+                } catch (Error e) { debug("Error loading icon from file: %s", e.message); }
             }
         }
         IconPixmapStruct[]? pixmaps = needs_attention ? get_attention_icon_pixmap() : get_icon_pixmap();
@@ -315,7 +265,7 @@ public class TrayIcon : Gtk.EventBox {
                         var pixbuf = new Gdk.Pixbuf.from_file_at_scale(icon_file, 16, 16, true);
                         icon_image.set_from_pixbuf(pixbuf);
                         return true;
-                    } catch (Error e) {}
+                    } catch (Error e) { debug("Error loading icon from file: %s", e.message); }
                 }
             }
         }
@@ -333,35 +283,33 @@ public class TrayIcon : Gtk.EventBox {
             }
         }
         var pixmap = pixmaps[best_idx];
-        try {
-            int width = pixmap.width;
-            int height = pixmap.height;
-            uint8[] data = pixmap.data;
-            int expected_size = width * height * 4;
-            if (data.length < expected_size) return false;
-            uint8[] rgba_data = new uint8[expected_size];
-            for (int i = 0; i < width * height; i++) {
-                int src_idx = i * 4;
-                int dst_idx = i * 4;
-                uint8 a = data[src_idx + 0];
-                uint8 r = data[src_idx + 1];
-                uint8 g = data[src_idx + 2];
-                uint8 b = data[src_idx + 3];
-                rgba_data[dst_idx + 0] = r;
-                rgba_data[dst_idx + 1] = g;
-                rgba_data[dst_idx + 2] = b;
-                rgba_data[dst_idx + 3] = a;
-            }
-            var pixbuf = new Gdk.Pixbuf.from_data(
-                rgba_data,
-                Gdk.Colorspace.RGB,
-                true, 8, width, height, width * 4
-            );
-            if (width != 16 || height != 16)
-                pixbuf = pixbuf.scale_simple(16, 16, Gdk.InterpType.BILINEAR);
-            icon_image.set_from_pixbuf(pixbuf);
-            return true;
-        } catch (Error e) { return false; }
+        int width = pixmap.width;
+        int height = pixmap.height;
+        uint8[] data = pixmap.data;
+        int expected_size = width * height * 4;
+        if (data.length < expected_size) return false;
+        uint8[] rgba_data = new uint8[expected_size];
+        for (int i = 0; i < width * height; i++) {
+            int src_idx = i * 4;
+            int dst_idx = i * 4;
+            uint8 a = data[src_idx + 0];
+            uint8 r = data[src_idx + 1];
+            uint8 g = data[src_idx + 2];
+            uint8 b = data[src_idx + 3];
+            rgba_data[dst_idx + 0] = r;
+            rgba_data[dst_idx + 1] = g;
+            rgba_data[dst_idx + 2] = b;
+            rgba_data[dst_idx + 3] = a;
+        }
+        var pixbuf = new Gdk.Pixbuf.from_data(
+            rgba_data,
+            Gdk.Colorspace.RGB,
+            true, 8, width, height, width * 4
+        );
+        if (width != 16 || height != 16)
+            pixbuf = pixbuf.scale_simple(16, 16, Gdk.InterpType.BILINEAR);
+        icon_image.set_from_pixbuf(pixbuf);
+        return true;
     }
 
     private void update_tooltip() {
@@ -384,28 +332,26 @@ public class TrayIcon : Gtk.EventBox {
         if (item_proxy == null && freedesktop_proxy == null) return false;
         int x = (int)event.x_root;
         int y = (int)event.y_root;
-        try {
-            if (event.button == Gdk.BUTTON_PRIMARY) {
+        if (event.button == Gdk.BUTTON_PRIMARY) {
+            if (use_freedesktop_interface && freedesktop_proxy != null)
+                freedesktop_proxy.Activate.begin(x, y);
+            else if (item_proxy != null)
+                item_proxy.Activate.begin(x, y);
+        } else if (event.button == Gdk.BUTTON_SECONDARY) {
+            if (dbusmenu != null)
+                dbusmenu.popup_at_pointer(event);
+            else {
                 if (use_freedesktop_interface && freedesktop_proxy != null)
-                    freedesktop_proxy.Activate.begin(x, y);
+                    freedesktop_proxy.ContextMenu.begin(x, y);
                 else if (item_proxy != null)
-                    item_proxy.Activate.begin(x, y);
-            } else if (event.button == Gdk.BUTTON_SECONDARY) {
-                if (dbusmenu != null)
-                    dbusmenu.popup_at_pointer(event);
-                else {
-                    if (use_freedesktop_interface && freedesktop_proxy != null)
-                        freedesktop_proxy.ContextMenu.begin(x, y);
-                    else if (item_proxy != null)
-                        item_proxy.ContextMenu.begin(x, y);
-                }
-            } else if (event.button == Gdk.BUTTON_MIDDLE) {
-                if (use_freedesktop_interface && freedesktop_proxy != null)
-                    freedesktop_proxy.SecondaryActivate.begin(x, y);
-                else if (item_proxy != null)
-                    item_proxy.SecondaryActivate.begin(x, y);
+                    item_proxy.ContextMenu.begin(x, y);
             }
-        } catch (Error e) {}
+        } else if (event.button == Gdk.BUTTON_MIDDLE) {
+            if (use_freedesktop_interface && freedesktop_proxy != null)
+                freedesktop_proxy.SecondaryActivate.begin(x, y);
+            else if (item_proxy != null)
+                item_proxy.SecondaryActivate.begin(x, y);
+        }
         return true;
     }
 
@@ -426,12 +372,10 @@ public class TrayIcon : Gtk.EventBox {
                 break;
         }
         if (delta != 0) {
-            try {
-                if (use_freedesktop_interface && freedesktop_proxy != null)
-                    freedesktop_proxy.Scroll.begin(delta, orientation);
-                else if (item_proxy != null)
-                    item_proxy.Scroll.begin(delta, orientation);
-            } catch (Error e) {}
+            if (use_freedesktop_interface && freedesktop_proxy != null)
+                freedesktop_proxy.Scroll.begin(delta, orientation);
+            else if (item_proxy != null)
+                item_proxy.Scroll.begin(delta, orientation);
         }
         return true;
     }


### PR DESCRIPTION
- Added a pan-down/up indicator icon to display widget to act as a chevron.
- Refactored Indicator lifecycle: linked icon state (chevron direction) to popover opened/closed signals.
- Updated TrayIcon scaling: increased base icon size and pixbuf scaling from 16px to 20px for better visibility.
- Added 'clicked' signal to TrayIcon to handle internal indicator interactions without triggering D-Bus warnings.
- Switched display container from Gtk.Box to Gtk.Grid.
